### PR TITLE
Fix history bugs (redo fast-forward and orphaned settings actions)

### DIFF
--- a/src/components/pdx/base-layer-slider.vue
+++ b/src/components/pdx/base-layer-slider.vue
@@ -49,7 +49,13 @@ const thumbRow = ref(props.editor.baseLayer.getRows())
 const thumbCssTop = ref(0)
 
 watch(thumbRow, () => {
-  props.editor.baseLayer.setRows(thumbRow.value)
+  // Route drags through the editor's setter so the history action survives
+  // being consumed mid-drag (e.g. by undoing). When the change is external
+  // (undo, opening a level) the editor already has the value and writing it
+  // back would wrongly create a history action, so only write while dragging.
+  if (pointerId.value !== undefined) {
+    props.editor.setBaseLayerRows(thumbRow.value)
+  }
 })
 
 /**

--- a/src/components/pdx/level-settings/banned-color.vue
+++ b/src/components/pdx/level-settings/banned-color.vue
@@ -59,7 +59,7 @@ const {
 const onColorChange = () => {
   const color = Number.parseInt(colorSelector.value?.value ?? '', 10)
   const oldColor = props.editor.baseLayer.getBannedColor()
-  const before = props.editor.saveForHistory()
+  const before = props.editor.history.captureBefore()
 
   if (color in BlockColor && color !== BlockColor.GRAY) {
     if (oldColor !== color) {

--- a/src/components/pdx/level-settings/index.vue
+++ b/src/components/pdx/level-settings/index.vue
@@ -7,7 +7,7 @@
     </div>
 
     <pdx-input-text
-      v-model="editor.levelName.value"
+      v-model="levelName"
       label="Level name"
       :tooltip="'Name of the level in-game,\nseparate from the file name'"
       :allowed-chars="VALID_CHARS"
@@ -17,7 +17,7 @@
     />
 
     <pdx-input-number
-      v-model="editor.seed.value"
+      v-model="rngSeed"
       label="RNG seed"
       tooltip="Value to initialize RNG after the level loads"
       :min="0"
@@ -65,14 +65,24 @@ const props = defineProps<{
 
 provideTooltipRefs()
 
+const levelName = computed({
+  get: () => props.editor.getLevelName(),
+  set: name => props.editor.setLevelName(name),
+})
+
+const rngSeed = computed({
+  get: () => props.editor.getRngSeed(),
+  set: seed => props.editor.setRngSeed(seed),
+})
+
 const baseLayerSeed = computed({
   get: () => props.editor.baseLayer.getSeed(),
-  set: val => props.editor.baseLayer.setSeed(val),
+  set: val => props.editor.setBaseLayerSeed(val),
 })
 
 const baseLayerRows = computed({
   get: () => props.editor.baseLayer.getRows(),
-  set: val => props.editor.baseLayer.setRows(val),
+  set: val => props.editor.setBaseLayerRows(val),
 })
 </script>
 

--- a/src/components/pdx/status-bar.vue
+++ b/src/components/pdx/status-bar.vue
@@ -34,12 +34,12 @@ const contextInfo = computed(() => {
     const { row, col } = props.editor.mouseCoordinates.value
     return `(Row, Column) = (${row}, ${col})`
   } else {
-    return `${props.editor.levelName.value}${hasUnsavedChanges.value ? ' \u25cf' : ''}`
+    return `${props.editor.getLevelName()}${hasUnsavedChanges.value ? ' \u25cf' : ''}`
   }
 })
 
 watch(
-  [hasUnsavedChanges, () => props.editor.levelName.value],
+  [hasUnsavedChanges, () => props.editor.getLevelName()],
   ([unsaved, levelName]) => {
     // U+25CF = filled circle
     const windowTitle = `${unsaved ? '\u25cf ' : ''}${levelName}`

--- a/src/types/Editor.ts
+++ b/src/types/Editor.ts
@@ -45,7 +45,7 @@ export class Editor {
 
   readonly selectedJunk: ShallowRef<Junk | null> = shallowRef(null)
 
-  readonly levelName: Ref<string> = ref('Untitled')
+  private readonly levelName: Ref<string> = ref('Untitled')
 
   /**
    * All players' random generators will be initalized to this value when the
@@ -53,7 +53,7 @@ export class Editor {
    * will always have the same results. As far as the level editor is concerned,
    * it's just a number that doesn't affect anything.
    */
-  readonly seed: Ref<number>
+  private readonly seed: Ref<number>
 
   /**
    * State of the tool selected on the left mouse button
@@ -215,6 +215,40 @@ export class Editor {
         this.deselectJunk()
       }
     }
+  }
+
+  // Edits to settings via text/number inputs must go through these setters
+  // rather than writing the state directly, so `this.history`'s pending action
+  // is recreated if something consumed it while the input was focused (e.g.
+  // undoing or saving mid-edit). Like brushes, the continue call must come
+  // before the update, so the history action has the correct "before" state.
+
+  getLevelName(): string {
+    return this.levelName.value
+  }
+
+  setLevelName(name: string): void {
+    this.history.continueLevelName()
+    this.levelName.value = name
+  }
+
+  getRngSeed(): number {
+    return this.seed.value
+  }
+
+  setRngSeed(seed: number): void {
+    this.history.continueRngSeed()
+    this.seed.value = seed
+  }
+
+  setBaseLayerSeed(seed: number): void {
+    this.history.continueBaseLayerSeed()
+    this.baseLayer.setSeed(seed)
+  }
+
+  setBaseLayerRows(rows: number): void {
+    this.history.continueBaseLayerRows()
+    this.baseLayer.setRows(rows)
   }
 
   selectBrush(
@@ -441,7 +475,7 @@ export class Editor {
         return
     }
 
-    const before = this.saveForHistory()
+    const before = this.history.captureBefore()
     const numJunkBefore = this.junkLayer.board.getJunk().length
 
     const result = this.junkLayer.onCellDrop(event, row, col)
@@ -496,7 +530,7 @@ export class Editor {
 
   setSelectedJunkColor(color: BlockColor): void {
     if (this.selectedJunk.value) {
-      const before = this.saveForHistory()
+      const before = this.history.captureBefore()
       this.selectedJunk.value.color = color
       this.history.pushEditJunk(before)
     }
@@ -504,7 +538,7 @@ export class Editor {
 
   setSelectedJunkEffect(effect: JunkEffect | null): void {
     if (this.selectedJunk.value) {
-      const before = this.saveForHistory()
+      const before = this.history.captureBefore()
       this.selectedJunk.value.activeEffect = effect
       this.history.pushEditJunk(before)
     }
@@ -512,7 +546,7 @@ export class Editor {
 
   deleteSelectedJunk(): void {
     if (this.selectedJunk.value) {
-      const before = this.saveForHistory()
+      const before = this.history.captureBefore()
       this.junkLayer.board.removeJunk(this.selectedJunk.value)
       this.deselectJunk()
       this.history.pushDeleteJunk(before)

--- a/src/types/History/History.ts
+++ b/src/types/History/History.ts
@@ -13,6 +13,16 @@ import type {
 import { ActionKind } from '@/types/History/Action'
 import { notNull } from '@/utils/notNull'
 
+const captured = Symbol('captured')
+
+/**
+ * Forces the Editor to call `captureBefore` before it can call one of the
+ * public `pushX` methods. See {@link History#captureBefore} for more info.
+ */
+interface CapturedLevel extends SavedLevel {
+  [captured]: true
+}
+
 /**
  * Maintains record history of editor actions, enabling undo/redo functionality.
  */
@@ -70,7 +80,7 @@ export class History {
 
   private pushSimpleAction(
     kind: (JunkAction | SettingsAction)['kind'],
-    before: SavedLevel
+    before: CapturedLevel
   ): void {
     const after = this.editor.saveForHistory()
     // Skip no-ops so they don't flood the history (e.g. repeatedly applying the
@@ -92,6 +102,12 @@ export class History {
     this.trimStack()
   }
 
+  /**
+   * Create a pending settings action of the given kind, unless a matching one
+   * already exists. The public `continueX` methods reuse this no-op behavior to
+   * recreate a pending that was consumed mid-edit (e.g. by undo/redo/save
+   * while the input stayed focused), so later edits are still recorded.
+   */
   private startSettingsAction(kind: SettingsAction['kind']): void {
     if (this.pending.value?.action.kind !== kind) {
       this.pushPending()
@@ -209,23 +225,45 @@ export class History {
     }
   }
 
-  pushMoveJunk(before: SavedLevel): void {
+  /**
+   * Flush any pending action, then return a snapshot of the editor's current
+   * state. Simple actions (no separate start and end) must capture their
+   * `before` state with this rather than `Editor.saveForHistory`. This is to
+   * encourage callers to flush the pending action before applying a change and
+   * calling a `pushX` method. If an action was still pending when the editor
+   * made a change, and a `pushX` method was only called afterwards, the pending
+   * action would be committed with an `after` state that includes the change,
+   * so redoing it would fast forward too far.
+   */
+  captureBefore(): CapturedLevel {
+    this.pushPending()
+    return {
+      ...this.editor.saveForHistory(),
+      [captured]: true,
+    }
+  }
+
+  pushMoveJunk(before: CapturedLevel): void {
     this.pushSimpleAction(ActionKind.MOVE_JUNK, before)
   }
 
-  pushCopyJunk(before: SavedLevel): void {
+  pushCopyJunk(before: CapturedLevel): void {
     this.pushSimpleAction(ActionKind.COPY_JUNK, before)
   }
 
-  pushEditJunk(before: SavedLevel): void {
+  pushEditJunk(before: CapturedLevel): void {
     this.pushSimpleAction(ActionKind.EDIT_JUNK, before)
   }
 
-  pushDeleteJunk(before: SavedLevel): void {
+  pushDeleteJunk(before: CapturedLevel): void {
     this.pushSimpleAction(ActionKind.DELETE_JUNK, before)
   }
 
   startLevelName(): void {
+    this.startSettingsAction(ActionKind.LEVEL_NAME)
+  }
+
+  continueLevelName(): void {
     this.startSettingsAction(ActionKind.LEVEL_NAME)
   }
 
@@ -237,11 +275,19 @@ export class History {
     this.startSettingsAction(ActionKind.GAME_RNG_SEED)
   }
 
+  continueRngSeed(): void {
+    this.startSettingsAction(ActionKind.GAME_RNG_SEED)
+  }
+
   endRngSeed(): void {
     this.endSettingsAction(ActionKind.GAME_RNG_SEED)
   }
 
   startBaseLayerSeed(): void {
+    this.startSettingsAction(ActionKind.BASE_LAYER_SEED)
+  }
+
+  continueBaseLayerSeed(): void {
     this.startSettingsAction(ActionKind.BASE_LAYER_SEED)
   }
 
@@ -253,11 +299,15 @@ export class History {
     this.startSettingsAction(ActionKind.BASE_LAYER_ROWS)
   }
 
+  continueBaseLayerRows(): void {
+    this.startSettingsAction(ActionKind.BASE_LAYER_ROWS)
+  }
+
   endBaseLayerRows(): void {
     this.endSettingsAction(ActionKind.BASE_LAYER_ROWS)
   }
 
-  pushSetBannedColor(before: SavedLevel): void {
+  pushSetBannedColor(before: CapturedLevel): void {
     this.pushSimpleAction(ActionKind.BANNED_COLOR, before)
   }
 


### PR DESCRIPTION
- Fixed history actions being orphaned if the undo, redo, or save hotkeys were used while editing a text input
- Fixed the "after" state for pending actions pushed before "simple" actions (atomic, i.e. no separate start and end phases) containing the same "after" state as the simple action (redoing change A would effectively also redo change B)